### PR TITLE
[FEAT] 디자인 토큰을 세팅한다.

### DIFF
--- a/src/styles/palette.ts
+++ b/src/styles/palette.ts
@@ -1,0 +1,33 @@
+export const palette = {
+  // blue
+  blue300: '#66BFFF',
+  blue400: '#339FFF',
+  blue500: '#2196f3',
+  blue600: '#005FCC',
+  blue700: '#003F7F',
+  // pink
+  pink300: '#F1A5B5',
+  pink500: '#E3879E',
+  pink600: '#F1A5B5',
+  // purple
+  purple300: '#A1A6FF',
+  purple500: '#7D83FF',
+  purple600: '#5A61CC',
+  // green
+  green300: '#66D2D0',
+  green500: '#00A9A5',
+  green600: '#007D7A',
+  // yellow
+  yellow300: '#FFEB66',
+  yellow500: '#FFDD00',
+  yellow600: '#CCB000',
+  // grey
+  grey100: '#F2F2F2',
+  grey200: '#E0E0E0',
+  grey300: '#BDBDBD',
+  grey400: '#828282',
+  grey500: '#4F4F4F',
+  // etc
+  black: '#333333',
+  white: '#F9F9F9',
+};

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,11 +1,87 @@
 import { createTheme } from '@mui/material';
 
-const palette = {};
+const palette = {
+  // blue
+  blue300: '#66BFFF',
+  blue400: '#339FFF',
+  blue500: '#2196f3',
+  blue600: '#005FCC',
+  blue700: '#003F7F',
+  // pink
+  pink300: '#F1A5B5',
+  pink500: '#E3879E',
+  pink600: '#F1A5B5',
+  // purple
+  purple300: '#A1A6FF',
+  purple500: '#7D83FF',
+  purple600: '#5A61CC',
+  // green
+  green300: '#66D2D0',
+  green500: '#00A9A5',
+  green600: '#007D7A',
+  // yellow
+  yellow300: '#FFEB66',
+  yellow500: '#FFDD00',
+  yellow600: '#CCB000',
+  // grey
+  grey100: '#F2F2F2',
+  grey200: '#E0E0E0',
+  grey300: '#BDBDBD',
+  grey400: '#828282',
+  grey500: '#4F4F4F',
+  // etc
+  black: '#333333',
+  white: '#F9F9F9',
+};
 
-const theme = createTheme({
-  palette,
+export const lightTheme = createTheme({
+  palette: {
+    mode: 'light',
+
+    primary: {
+      main: palette.blue500,
+      light: palette.blue300,
+      dark: palette.blue600,
+    },
+    secondary: {
+      main: palette.pink500,
+      light: palette.pink300,
+      dark: palette.pink600,
+    },
+    background: {
+      default: palette.white,
+    },
+    text: {
+      primary: palette.black,
+      secondary: palette.grey500,
+    },
+    ...palette,
+  },
 });
 
-export default theme;
+export const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
 
-export type ThemeType = typeof theme;
+    primary: {
+      main: palette.blue500,
+      light: palette.blue300,
+      dark: palette.blue600,
+    },
+    secondary: {
+      main: palette.pink500,
+      light: palette.pink300,
+      dark: palette.pink600,
+    },
+    background: {
+      default: palette.black,
+    },
+    text: {
+      primary: palette.white,
+      secondary: palette.grey300,
+    },
+    ...palette,
+  },
+});
+
+export type ThemeType = typeof lightTheme;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,38 +1,6 @@
-import { createTheme } from '@mui/material';
-
-const palette = {
-  // blue
-  blue300: '#66BFFF',
-  blue400: '#339FFF',
-  blue500: '#2196f3',
-  blue600: '#005FCC',
-  blue700: '#003F7F',
-  // pink
-  pink300: '#F1A5B5',
-  pink500: '#E3879E',
-  pink600: '#F1A5B5',
-  // purple
-  purple300: '#A1A6FF',
-  purple500: '#7D83FF',
-  purple600: '#5A61CC',
-  // green
-  green300: '#66D2D0',
-  green500: '#00A9A5',
-  green600: '#007D7A',
-  // yellow
-  yellow300: '#FFEB66',
-  yellow500: '#FFDD00',
-  yellow600: '#CCB000',
-  // grey
-  grey100: '#F2F2F2',
-  grey200: '#E0E0E0',
-  grey300: '#BDBDBD',
-  grey400: '#828282',
-  grey500: '#4F4F4F',
-  // etc
-  black: '#333333',
-  white: '#F9F9F9',
-};
+import { palette } from '@/styles/palette';
+import { typography } from '@/styles/typography';
+import { createTheme } from '@mui/material/styles';
 
 export const lightTheme = createTheme({
   palette: {
@@ -57,6 +25,7 @@ export const lightTheme = createTheme({
     },
     ...palette,
   },
+  font: typography,
 });
 
 export const darkTheme = createTheme({
@@ -82,6 +51,7 @@ export const darkTheme = createTheme({
     },
     ...palette,
   },
+  font: typography,
 });
 
 export type ThemeType = typeof lightTheme;

--- a/src/styles/typography.ts
+++ b/src/styles/typography.ts
@@ -1,0 +1,48 @@
+export const typography = {
+  fontFamily: '"Roboto", "Arial", sans-serif',
+  h1: {
+    fontSize: '3.2rem',
+    fontWeight: 700,
+    lineHeight: 1.5,
+  },
+  h2: {
+    fontSize: '2.8rem',
+    fontWeight: 700,
+    lineHeight: 1.5,
+  },
+  h3: {
+    fontSize: '2.4rem',
+    fontWeight: 700,
+    lineHeight: 1.4,
+  },
+  h4: {
+    fontSize: '2rem',
+    fontWeight: 700,
+    lineHeight: 1.6,
+  },
+  h5: {
+    fontSize: '1.8rem',
+    fontWeight: 700,
+    lineHeight: 1.5,
+  },
+  h6: {
+    fontSize: '1.6rem',
+    fontWeight: 700,
+    lineHeight: 1.5,
+  },
+  body1: {
+    fontSize: '1.8rem',
+    fontWeight: 400,
+    lineHeight: 1.5,
+  },
+  body2: {
+    fontSize: '1.6rem',
+    fontWeight: 400,
+    lineHeight: 1.5,
+  },
+  body3: {
+    fontSize: '1.2rem',
+    fontWeight: 400,
+    textTransform: 'none',
+  },
+};

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,3 +1,5 @@
+import '@mui/material/styles/createPalette';
+
 declare module '@mui/material/styles' {
   interface Palette {
     blue300: string;
@@ -52,4 +54,6 @@ declare module '@mui/material/styles' {
     black?: string;
     white?: string;
   }
+
+  export function createTheme(options: ThemeOptions): Theme;
 }

--- a/src/types/theme.d.ts
+++ b/src/types/theme.d.ts
@@ -1,0 +1,55 @@
+declare module '@mui/material/styles' {
+  interface Palette {
+    blue300: string;
+    blue400: string;
+    blue500: string;
+    blue600: string;
+    blue700: string;
+    pink300: string;
+    pink500: string;
+    pink600: string;
+    purple300: string;
+    purple500: string;
+    purple600: string;
+    green300: string;
+    green500: string;
+    green600: string;
+    yellow300: string;
+    yellow500: string;
+    yellow600: string;
+    grey100: string;
+    grey200: string;
+    grey300: string;
+    grey400: string;
+    grey500: string;
+    black: string;
+    white: string;
+  }
+
+  interface PaletteOptions {
+    blue300?: string;
+    blue400?: string;
+    blue500?: string;
+    blue600?: string;
+    blue700?: string;
+    pink300?: string;
+    pink500?: string;
+    pink600?: string;
+    purple300?: string;
+    purple500?: string;
+    purple600?: string;
+    green300?: string;
+    green500?: string;
+    green600?: string;
+    yellow300?: string;
+    yellow500?: string;
+    yellow600?: string;
+    grey100?: string;
+    grey200?: string;
+    grey300?: string;
+    grey400?: string;
+    grey500?: string;
+    black?: string;
+    white?: string;
+  }
+}


### PR DESCRIPTION
## 💵 관련 이슈
#1 

## ✨ 구현한 기능

> 구현 기능에 대해 작성해주세요.

<img width="918" alt="스크린샷 2025-02-06 오후 6 05 10" src="https://github.com/user-attachments/assets/74960ed8-1739-455c-b68a-6a3443d8ed25" />

- MUI의 ThemeProvider를 활용하여 팔레트와 타이포그래피 설정을 디자인 토큰으로 관리하도록 변경했습니다.
   - 팔레트: 기본 색상, 강조 색상, 배경색, 텍스트 색상 등 설정
   - 타이포그래피: 기본 폰트 크기, 폰트 패밀리, 라인 높이 등 정의

- 모든 컴포넌트에서 공통으로 사용할 수 있도록 글로벌 테마 적용
- 라이트모드, 다크 모드 모두 지원

## 📢 논의하고 싶은 내용

> 고려해야 하는 내용을 작성해 주세요.

## 🍗 PR 첫 리뷰 마감 기한

02/07 12:00
