### PR TITLE
[FEAT] 에러 핸들링을 위해 지역 Error Boundary를 추가한다. 

### DIFF
--- a/src/components/AddMileage/EtcMileageSection.tsx
+++ b/src/components/AddMileage/EtcMileageSection.tsx
@@ -1,11 +1,22 @@
-import { Flex, Title } from '@/components';
+import { Flex, SectionErrorFallback, Title } from '@/components';
 import { EtcMileageTable } from '@/components/AddMileage';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
 
 const EtcMileageSection = () => {
   return (
     <Flex.Column height="50%">
       <Title label="신청 가능 마일리지" />
-      <EtcMileageTable />
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            FallbackComponent={SectionErrorFallback}
+            onReset={reset}
+          >
+            <EtcMileageTable />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </Flex.Column>
   );
 };

--- a/src/components/AddMileage/EtcMileageTable.tsx
+++ b/src/components/AddMileage/EtcMileageTable.tsx
@@ -1,19 +1,27 @@
 import { Table } from '@/components';
 import { AddMileageModal } from '@/components/AddMileage';
 import { useGetEtcMileageQuery } from '@/hooks/queries';
+import { useMemo } from 'react';
 
 const EtcMileageTable = () => {
   const { data: etcMileageList } = useGetEtcMileageQuery();
 
-  const bodyItems =
-    etcMileageList?.map(item => ({
-      semester: item.semester,
-      categoryName: item.categoryName,
-      subitemName: item.subitemName,
-      addModal: (
-        <AddMileageModal semester={item.semester} subitemId={item.subitemId} />
-      ),
-    })) ?? [];
+  const bodyItems = useMemo(
+    () =>
+      etcMileageList?.map((item, index) => ({
+        id: index + 1,
+        semester: item.semester,
+        categoryName: item.categoryName,
+        subitemName: item.subitemName,
+        addModal: (
+          <AddMileageModal
+            semester={item.semester}
+            subitemId={item.subitemId}
+          />
+        ),
+      })) ?? [],
+    [etcMileageList],
+  );
 
   return (
     <Table

--- a/src/components/AddMileage/SubmittedMileageSection.tsx
+++ b/src/components/AddMileage/SubmittedMileageSection.tsx
@@ -1,11 +1,22 @@
-import { Flex, Title } from '@/components';
+import { Flex, SectionErrorFallback, Title } from '@/components';
 import { SubmittedMileageTable } from '@/components/AddMileage';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
 
 const SubmittedMileageSection = () => {
   return (
     <Flex.Column height="50%">
       <Title label="신청 완료 마일리지" />
-      <SubmittedMileageTable />
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary
+            FallbackComponent={SectionErrorFallback}
+            onReset={reset}
+          >
+            <SubmittedMileageTable />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </Flex.Column>
   );
 };

--- a/src/components/AddMileage/SubmittedMileageTable.tsx
+++ b/src/components/AddMileage/SubmittedMileageTable.tsx
@@ -1,6 +1,7 @@
 import { Table } from '@/components';
 import { useGetSubmittedMileageQuery } from '@/hooks/queries';
 import { useAuthStore } from '@/stores';
+import { useMemo } from 'react';
 
 const SubmittedMileageTable = () => {
   const { student } = useAuthStore();
@@ -8,14 +9,17 @@ const SubmittedMileageTable = () => {
     student?.studentId ?? '',
   );
 
-  const bodyItems =
-    submittedMileageList?.map(item => ({
-      semester: item.semester,
-      subitemName: item.subitemName,
-      description1: item.description1,
-      modDate: item.modDate,
-      addModal: <></>,
-    })) ?? [];
+  const bodyItems = useMemo(
+    () =>
+      submittedMileageList?.map(item => ({
+        semester: item.semester,
+        subitemName: item.subitemName,
+        description1: item.description1,
+        modDate: item.modDate,
+        addModal: <></>,
+      })) ?? [],
+    [submittedMileageList],
+  );
 
   return (
     <Table

--- a/src/components/MileageList/MileageFilterSection.tsx
+++ b/src/components/MileageList/MileageFilterSection.tsx
@@ -4,13 +4,16 @@ import {
   SearchMileageInput,
   SemesterDropdown,
 } from '@/components/MileageList';
+import { ErrorBoundary } from 'react-error-boundary';
 
 const MileageFilterSection = () => {
   return (
     <Flex.Column>
       <Flex.Row height="40px" margin="1rem 0" align="center" gap="1rem">
         <SearchMileageInput />
-        <SemesterDropdown />
+        <ErrorBoundary fallback={<div />}>
+          <SemesterDropdown />
+        </ErrorBoundary>
       </Flex.Row>
       <JoinedTabs />
     </Flex.Column>

--- a/src/components/MileageList/MileageTable.tsx
+++ b/src/components/MileageList/MileageTable.tsx
@@ -1,18 +1,23 @@
 import { Table } from '@/components';
 import { MileageResponse } from '@/types/mileage';
+import { useMemo } from 'react';
 
 interface Props {
   mileageList: MileageResponse[];
 }
 
 const MileageTable = ({ mileageList }: Props) => {
-  const bodyItems = mileageList.map((item, index) => ({
-    id: index + 1,
-    semester: item.semester,
-    categoryName: item.categoryName,
-    description: item.description,
-    done: item.done ? 'Y' : 'N',
-  }));
+  const bodyItems = useMemo(
+    () =>
+      mileageList.map((item, index) => ({
+        id: index + 1,
+        semester: item.semester,
+        categoryName: item.categoryName,
+        description: item.description,
+        done: item.done ? 'Y' : 'N',
+      })),
+    [mileageList],
+  );
 
   return (
     <Table

--- a/src/components/ScholarshipApply/MileageBannerSection.tsx
+++ b/src/components/ScholarshipApply/MileageBannerSection.tsx
@@ -1,17 +1,12 @@
-import { Flex, Text } from '@/components';
-import { useGetMileageQuery } from '@/hooks/queries';
+import { CountBoxFallback, Flex, Text } from '@/components';
+import MileageCountBox from '@/components/ScholarshipApply/MileageCountBox';
 import { useAuthStore } from '@/stores';
 import { boxShadow } from '@/styles/common';
 import { styled } from '@mui/material';
+import { ErrorBoundary } from 'react-error-boundary';
 
-const MileageCountSection = () => {
+const MileageBannerSection = () => {
   const { student, currentSemester } = useAuthStore();
-
-  const { data: mileageList } = useGetMileageQuery({
-    studentId: student?.studentId ?? '',
-    semester: currentSemester ?? '',
-    done: 'Y',
-  });
 
   return (
     <S.Wrapper justify="center" align="center">
@@ -23,20 +18,15 @@ const MileageCountSection = () => {
           <span style={{ fontWeight: 'bold' }}>{currentSemester} 학기 </span>
           등록하신 마일리지입니다
         </Text>
-        <S.CountContainer>
-          <Flex.Column align="center">
-            <Flex.Row style={{ fontSize: '1rem' }}>마일리지 개수</Flex.Row>
-            <Flex.Row align="baseline" gap=".5rem">
-              <S.CountNumber>{mileageList?.length}</S.CountNumber>개
-            </Flex.Row>
-          </Flex.Column>
-        </S.CountContainer>
+        <ErrorBoundary FallbackComponent={CountBoxFallback}>
+          <MileageCountBox />
+        </ErrorBoundary>
       </S.Container>
     </S.Wrapper>
   );
 };
 
-export default MileageCountSection;
+export default MileageBannerSection;
 
 const S = {
   Wrapper: styled(Flex.Row)`

--- a/src/components/ScholarshipApply/MileageCountBox.tsx
+++ b/src/components/ScholarshipApply/MileageCountBox.tsx
@@ -1,0 +1,56 @@
+import { Flex } from '@/components';
+import { useGetMileageQuery } from '@/hooks/queries';
+import { useAuthStore } from '@/stores';
+import { boxShadow } from '@/styles/common';
+import { styled } from '@mui/material';
+
+const MileageCountBox = () => {
+  const { student, currentSemester } = useAuthStore();
+
+  const { data: mileageList } = useGetMileageQuery({
+    studentId: student?.studentId ?? '',
+    semester: currentSemester ?? '',
+    done: 'Y',
+  });
+
+  return (
+    <S.CountContainer>
+      <Flex.Column align="center">
+        <Flex.Row style={{ fontSize: '1rem' }}>마일리지 개수</Flex.Row>
+        <Flex.Row align="baseline" gap=".5rem">
+          <S.CountNumber>{mileageList?.length ?? 0}</S.CountNumber>개
+        </Flex.Row>
+      </Flex.Column>
+    </S.CountContainer>
+  );
+};
+
+export default MileageCountBox;
+
+const S = {
+  Container: styled(Flex.Column)`
+    background-color: ${({ theme }) => theme.palette.primary.main};
+    border-radius: 1rem;
+    color: ${({ theme }) => theme.palette.white};
+    height: 110px;
+    position: relative;
+    width: 80%;
+  `,
+  CountContainer: styled(Flex.Column)`
+    background-color: ${({ theme }) => theme.palette.white};
+    border-radius: 1rem;
+    color: ${({ theme }) => theme.palette.black};
+    height: 110px;
+    padding: 1rem;
+    position: absolute;
+    right: 10%;
+    top: -30%;
+    width: 20%;
+    ${boxShadow}
+  `,
+  CountNumber: styled(Flex.Row)`
+    color: ${({ theme }) => theme.palette.primary.main};
+    font-size: 2.5rem;
+    font-weight: bold;
+  `,
+};

--- a/src/components/ScholarshipApply/index.ts
+++ b/src/components/ScholarshipApply/index.ts
@@ -1,4 +1,5 @@
 export { default as ApplySection } from './ApplySection';
 export { default as ApplySucceedModal } from './ApplySucceedModal';
 export { default as ConsentSection } from './ConsentSection';
-export { default as MileageCountSection } from './MileageCountSection';
+export { default as MileageBannerSection } from './MileageBannerSection';
+export { default as MileageCountBox } from './MileageCountBox';

--- a/src/components/_common/Error/CountBoxFallback.tsx
+++ b/src/components/_common/Error/CountBoxFallback.tsx
@@ -1,0 +1,46 @@
+import { Flex } from '@/components';
+import { boxShadow } from '@/styles/common';
+import { styled } from '@mui/material';
+
+const CountBoxFallback = () => {
+  return (
+    <S.CountContainer>
+      <Flex.Column align="center">
+        <Flex.Row style={{ fontSize: '1rem' }}>마일리지 개수</Flex.Row>
+        <Flex.Row align="baseline" gap=".5rem">
+          <S.CountNumber>N</S.CountNumber>개
+        </Flex.Row>
+      </Flex.Column>
+    </S.CountContainer>
+  );
+};
+
+export default CountBoxFallback;
+
+const S = {
+  Container: styled(Flex.Column)`
+    background-color: ${({ theme }) => theme.palette.primary.main};
+    border-radius: 1rem;
+    color: ${({ theme }) => theme.palette.white};
+    height: 110px;
+    position: relative;
+    width: 80%;
+  `,
+  CountContainer: styled(Flex.Column)`
+    background-color: ${({ theme }) => theme.palette.white};
+    border-radius: 1rem;
+    color: ${({ theme }) => theme.palette.black};
+    height: 110px;
+    padding: 1rem;
+    position: absolute;
+    right: 10%;
+    top: -30%;
+    width: 20%;
+    ${boxShadow}
+  `,
+  CountNumber: styled(Flex.Row)`
+    color: ${({ theme }) => theme.palette.primary.main};
+    font-size: 2.5rem;
+    font-weight: bold;
+  `,
+};

--- a/src/components/_common/Error/GlobalErrorBoundary.tsx
+++ b/src/components/_common/Error/GlobalErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { ErrorFallbackSection } from '@/components';
+import { GlobalErrorFallbackSection } from '@/components';
 import { useQueryErrorResetBoundary } from '@tanstack/react-query';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -9,7 +9,7 @@ const GlobalErrorBoundary = ({ children }: { children: JSX.Element }) => {
     <ErrorBoundary
       onReset={reset}
       FallbackComponent={({ error, resetErrorBoundary }) => (
-        <ErrorFallbackSection
+        <GlobalErrorFallbackSection
           error={error}
           resetErrorBoundary={resetErrorBoundary}
         />

--- a/src/components/_common/Error/GlobalErrorFallbackSection.tsx
+++ b/src/components/_common/Error/GlobalErrorFallbackSection.tsx
@@ -8,7 +8,7 @@ interface Props {
   resetErrorBoundary: () => void;
 }
 
-const ErrorFallbackSection = ({ error, resetErrorBoundary }: Props) => {
+const GlobalErrorFallbackSection = ({ error, resetErrorBoundary }: Props) => {
   const { logout } = useAuthStore();
   const navigate = useNavigate();
 
@@ -42,4 +42,4 @@ const ErrorFallbackSection = ({ error, resetErrorBoundary }: Props) => {
   );
 };
 
-export default ErrorFallbackSection;
+export default GlobalErrorFallbackSection;

--- a/src/components/_common/Error/PageErrorFallback.tsx
+++ b/src/components/_common/Error/PageErrorFallback.tsx
@@ -1,0 +1,29 @@
+import { EmptyBoxImg } from '@/assets';
+import { Button, Flex, Heading } from '@/components';
+import { useTheme } from '@mui/material';
+import { FallbackProps } from 'react-error-boundary';
+
+const PageErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const theme = useTheme();
+
+  return (
+    <Flex.Column
+      width="100%"
+      height="400px"
+      gap="1rem"
+      justify="center"
+      align="center"
+    >
+      <EmptyBoxImg />
+      <Heading
+        as="h2"
+        style={{ fontSize: '2rem', color: theme.palette.grey300 }}
+      >
+        헉 {error.status} 에러 발생 .. !
+      </Heading>
+      <Button label="다시 시도하기" onClick={resetErrorBoundary} />
+    </Flex.Column>
+  );
+};
+
+export default PageErrorFallback;

--- a/src/components/_common/Error/SectionErrorFallback.tsx
+++ b/src/components/_common/Error/SectionErrorFallback.tsx
@@ -14,7 +14,7 @@ const SectionErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
       justify="center"
       align="center"
     >
-      <EmptyBoxImg width={'75px'} height={'75px'} />
+      <EmptyBoxImg width={75} height={75} />
       <Heading
         as="h2"
         style={{ fontSize: '1.5rem', color: theme.palette.grey300 }}

--- a/src/components/_common/Error/SectionErrorFallback.tsx
+++ b/src/components/_common/Error/SectionErrorFallback.tsx
@@ -3,21 +3,21 @@ import { Button, Flex, Heading } from '@/components';
 import { useTheme } from '@mui/material';
 import { FallbackProps } from 'react-error-boundary';
 
-const TableErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+const SectionErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   const theme = useTheme();
 
   return (
     <Flex.Column
       width="100%"
-      height="400px"
+      height="200px"
       gap="1rem"
       justify="center"
       align="center"
     >
-      <EmptyBoxImg />
+      <EmptyBoxImg width={'75px'} height={'75px'} />
       <Heading
         as="h2"
-        style={{ fontSize: '2rem', color: theme.palette.grey300 }}
+        style={{ fontSize: '1.5rem', color: theme.palette.grey300 }}
       >
         헉 {error.status} 에러 발생 .. !
       </Heading>
@@ -26,4 +26,4 @@ const TableErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
   );
 };
 
-export default TableErrorFallback;
+export default SectionErrorFallback;

--- a/src/components/_common/Error/TableErrorFallback.tsx
+++ b/src/components/_common/Error/TableErrorFallback.tsx
@@ -1,0 +1,29 @@
+import { EmptyBoxImg } from '@/assets';
+import { Button, Flex, Heading } from '@/components';
+import { useTheme } from '@mui/material';
+import { FallbackProps } from 'react-error-boundary';
+
+const TableErrorFallback = ({ error, resetErrorBoundary }: FallbackProps) => {
+  const theme = useTheme();
+
+  return (
+    <Flex.Column
+      width="100%"
+      height="400px"
+      gap="1rem"
+      justify="center"
+      align="center"
+    >
+      <EmptyBoxImg />
+      <Heading
+        as="h2"
+        style={{ fontSize: '2rem', color: theme.palette.grey300 }}
+      >
+        헉 {error.status} 에러 발생 .. !
+      </Heading>
+      <Button label="다시 시도하기" onClick={resetErrorBoundary} />
+    </Flex.Column>
+  );
+};
+
+export default TableErrorFallback;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,7 @@
 export { default as Button } from './_common/Button/Button';
 export { default as Drawer } from './_common/Drawer/Drawer';
 export { default as Dropdown } from './_common/Dropdown/Dropdown';
+export { default as CountBoxFallback } from './_common/Error/CountBoxFallback';
 export { default as ErrorResetBoundary } from './_common/Error/ErrorResetBoundary';
 export { default as GlobalErrorBoundary } from './_common/Error/GlobalErrorBoundary';
 export { default as GlobalErrorFallbackSection } from './_common/Error/GlobalErrorFallbackSection';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,9 +1,9 @@
 export { default as Button } from './_common/Button/Button';
 export { default as Drawer } from './_common/Drawer/Drawer';
 export { default as Dropdown } from './_common/Dropdown/Dropdown';
-export { default as ErrorFallbackSection } from './_common/Error/ErrorFallbackSection';
 export { default as ErrorResetBoundary } from './_common/Error/ErrorResetBoundary';
 export { default as GlobalErrorBoundary } from './_common/Error/GlobalErrorBoundary';
+export { default as GlobalErrorFallbackSection } from './_common/Error/GlobalErrorFallbackSection';
 export { default as GlobalSuspense } from './_common/Error/GlobalSuspense';
 export { default as Flex } from './_common/Flex/Flex';
 export { default as FormField } from './_common/FormField/FormField';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,7 +5,8 @@ export { default as ErrorResetBoundary } from './_common/Error/ErrorResetBoundar
 export { default as GlobalErrorBoundary } from './_common/Error/GlobalErrorBoundary';
 export { default as GlobalErrorFallbackSection } from './_common/Error/GlobalErrorFallbackSection';
 export { default as GlobalSuspense } from './_common/Error/GlobalSuspense';
-export { default as TableErrorFallback } from './_common/Error/TableErrorFallback';
+export { default as PageErrorFallback } from './_common/Error/PageErrorFallback';
+export { default as SectionErrorFallback } from './_common/Error/SectionErrorFallback';
 export { default as Flex } from './_common/Flex/Flex';
 export { default as FormField } from './_common/FormField/FormField';
 export { default as Header } from './_common/Header/Header';

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,6 +5,7 @@ export { default as ErrorResetBoundary } from './_common/Error/ErrorResetBoundar
 export { default as GlobalErrorBoundary } from './_common/Error/GlobalErrorBoundary';
 export { default as GlobalErrorFallbackSection } from './_common/Error/GlobalErrorFallbackSection';
 export { default as GlobalSuspense } from './_common/Error/GlobalSuspense';
+export { default as TableErrorFallback } from './_common/Error/TableErrorFallback';
 export { default as Flex } from './_common/Flex/Flex';
 export { default as FormField } from './_common/FormField/FormField';
 export { default as Header } from './_common/Header/Header';

--- a/src/mocks/handlers/mileage.ts
+++ b/src/mocks/handlers/mileage.ts
@@ -63,6 +63,12 @@ export const MileageHandlers = [
   }),
 
   http.get(BASE_URL + `${ENDPOINT.ETC_MILEAGE}/:studentId`, () => {
+    const { is400Error, is401Error, is500Error } = randomMswError();
+
+    if (is400Error) return Error400();
+    if (is401Error) return Error401();
+    if (is500Error) return Error500();
+
     return HttpResponse.json(
       { data: submittedMileage.getValue() },
       { status: 200 },
@@ -70,6 +76,12 @@ export const MileageHandlers = [
   }),
 
   http.get(BASE_URL + `${ENDPOINT.ETC_MILEAGE}`, () => {
+    const { is400Error, is401Error, is500Error } = randomMswError();
+
+    if (is400Error) return Error400();
+    if (is401Error) return Error401();
+    if (is500Error) return Error500();
+
     return HttpResponse.json({ data: mockEtcMileageList }, { status: 200 });
   }),
 

--- a/src/pages/AddMileagePage.tsx
+++ b/src/pages/AddMileagePage.tsx
@@ -3,10 +3,14 @@ import {
   EtcMileageSection,
   SubmittedMileageSection,
 } from '@/components/AddMileage';
+import { headerHeight } from '@/constants/layoutSize';
 
 const AddMileagePage = () => {
   return (
-    <Flex.Column margin="1rem 2rem" height="100%">
+    <Flex.Column
+      margin="1rem 2rem"
+      height={`calc(100% - ${headerHeight + 32}px)`}
+    >
       <EtcMileageSection />
       <SubmittedMileageSection />
     </Flex.Column>

--- a/src/pages/MileageListPage.tsx
+++ b/src/pages/MileageListPage.tsx
@@ -1,14 +1,22 @@
-import { Flex } from '@/components';
+import { Flex, TableErrorFallback } from '@/components';
 import {
   MileageFilterSection,
   MileageTableListSection,
 } from '@/components/MileageList';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { ErrorBoundary } from 'react-error-boundary';
 
 const MileageListPage = () => {
   return (
     <Flex.Column margin="1rem 2rem">
       <MileageFilterSection />
-      <MileageTableListSection />
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary FallbackComponent={TableErrorFallback} onReset={reset}>
+            <MileageTableListSection />
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </Flex.Column>
   );
 };

--- a/src/pages/MileageListPage.tsx
+++ b/src/pages/MileageListPage.tsx
@@ -1,4 +1,4 @@
-import { Flex, TableErrorFallback } from '@/components';
+import { Flex, PageErrorFallback } from '@/components';
 import {
   MileageFilterSection,
   MileageTableListSection,
@@ -12,7 +12,7 @@ const MileageListPage = () => {
       <MileageFilterSection />
       <QueryErrorResetBoundary>
         {({ reset }) => (
-          <ErrorBoundary FallbackComponent={TableErrorFallback} onReset={reset}>
+          <ErrorBoundary FallbackComponent={PageErrorFallback} onReset={reset}>
             <MileageTableListSection />
           </ErrorBoundary>
         )}

--- a/src/pages/ScholarshipApplyPage.tsx
+++ b/src/pages/ScholarshipApplyPage.tsx
@@ -2,7 +2,7 @@ import { Flex } from '@/components';
 import {
   ApplySection,
   ConsentSection,
-  MileageCountSection,
+  MileageBannerSection,
 } from '@/components/ScholarshipApply';
 import { useState } from 'react';
 
@@ -11,7 +11,7 @@ const ScholarshipApplyPage = () => {
 
   return (
     <Flex.Column gap="1rem">
-      <MileageCountSection />
+      <MileageBannerSection />
       <ConsentSection isAgree={isAgree} handleAgree={setIsAgree} />
       <ApplySection isAgree={isAgree} />
     </Flex.Column>


### PR DESCRIPTION
## 💵 관련 이슈

- #21 

## ✨ 구현한 기능

> 구현 기능에 대해 작성해주세요.

<img width="1440" alt="스크린샷 2025-02-23 오후 10 07 59" src="https://github.com/user-attachments/assets/b3b4305d-a4c9-4e21-8b16-149507b29372" />

### 에러 바운더리 설정
1. 조회 페이지 
2. 등록 페이지 내부 조회 테이블 
3. 장학금 신청 페이지의 마일리지 개수 배너 

에러가 발생할 수 있는 예외 상황에 대응하기 위해 에러 바운더리를 설정하여, 사용자가 에러 메시지를 볼 수 있도록 처리했습니다.
현재는 일단 대략 메세지를 적어놨는데 이후 워딩 수정이 필요합니다. 

### bodyItem useMemo로 메모이제이션

성능 최적화를 위해 bodyItem에서 메모이제이션을 적용하여 불필요한 재렌더링을 방지하고 렌더링 성능을 개선했습니다.

## 📢 논의하고 싶은 내용

> 고려해야 하는 내용을 작성해 주세요.

에러 메세지 구체화 논의 필요 

## 🍗 PR 첫 리뷰 마감 기한

00/00 00:00
