### PR TITLE
[FEAT] 프로젝트 아카이빙 조회 페이지를 작업한다. 

### DIFF
--- a/src/apis/endPoint.ts
+++ b/src/apis/endPoint.ts
@@ -12,4 +12,6 @@ export const ENDPOINT = {
   CAPABILITY: `/api/mileage/capability`,
   // award
   AWARD: `/api/mileage/award`,
+  // project
+  PROJECT: `/api/mileage/project`,
 };

--- a/src/assets/icons/plus.svg
+++ b/src/assets/icons/plus.svg
@@ -1,0 +1,3 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M5 12H19M12 19V5" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/assets/index.ts
+++ b/src/assets/index.ts
@@ -23,6 +23,7 @@ import MileageAddIcon from '@/assets/icons/mileageAdd.svg?react';
 import MileageAddBlueIcon from '@/assets/icons/mileageAddBlue.svg?react';
 import MileageListIcon from '@/assets/icons/mileageList.svg?react';
 import MileageListBlueIcon from '@/assets/icons/mileageListBlue.svg?react';
+import PlusIcon from '@/assets/icons/plus.svg?react';
 import ScholarshipIcon from '@/assets/icons/scholarship.svg?react';
 import ScholarshipBlueIcon from '@/assets/icons/scholarshipBlue.svg?react';
 import SearchIcon from '@/assets/icons/search.svg?react';
@@ -88,6 +89,7 @@ export {
   MileageListBlueIcon,
   MileageListIcon,
   MobileBackgroundImg,
+  PlusIcon,
   ChevronRightIcon as RightArrowIcon,
   ScholarshipBlueIcon,
   ScholarshipIcon,

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -40,7 +40,7 @@ const Button = ({
           backgroundColor: variant === 'contained' ? hoverColor : 'transparent',
           borderColor: variant === 'outlined' ? hoverColor : 'transparent',
         },
-        borderRadius: isRound ? '2.4rem' : '.75rem',
+        borderRadius: isRound ? '2.4rem' : '.5rem',
         width: size === 'full' ? '100%' : 'auto',
         height: size === 'small' ? '30px' : size === 'medium' ? '36px' : '42px',
       }}

--- a/src/constants/drawerItems.ts
+++ b/src/constants/drawerItems.ts
@@ -44,6 +44,13 @@ export const drawerItems = [
     route: ROUTE_PATH.award,
   },
   {
+    text: '프로젝트',
+    shortText: '프로젝트',
+    icon: AwardListIcon,
+    selectedIcon: AwardListBlueIcon,
+    route: ROUTE_PATH.project,
+  },
+  {
     text: '장학금 신청',
     shortText: '장학금 신청',
     icon: ScholarshipIcon,

--- a/src/constants/headerItems.ts
+++ b/src/constants/headerItems.ts
@@ -5,6 +5,7 @@ export const headerItems = {
   [ROUTE_PATH.mileageList]: '마일리지 조회',
   [ROUTE_PATH.newMileage]: '마일리지 등록',
   [ROUTE_PATH.award]: '상장 조회',
+  [ROUTE_PATH.project]: '프로젝트',
   [ROUTE_PATH.scholarship]: '장학금 신청',
   [ROUTE_PATH.myPage]: '마이페이지',
 };

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -4,6 +4,7 @@ export const ROUTE_PATH = {
   mileageList: '/mileage',
   newMileage: '/mileage/add',
   award: '/award',
+  project: '/project',
   projectDetail: (id: number) => `/project/${id}`,
   newProject: '/project/add',
   scholarship: '/scholarship/apply',

--- a/src/constants/routePath.ts
+++ b/src/constants/routePath.ts
@@ -4,6 +4,8 @@ export const ROUTE_PATH = {
   mileageList: '/mileage',
   newMileage: '/mileage/add',
   award: '/award',
+  projectDetail: (id: number) => `/project/${id}`,
+  newProject: '/project/add',
   scholarship: '/scholarship/apply',
   myPage: '/my',
 };

--- a/src/mocks/fixtures/projectList.ts
+++ b/src/mocks/fixtures/projectList.ts
@@ -1,0 +1,169 @@
+import { ProjectResponse } from '@/pages/ProjectArchivePage/types/project';
+
+export const mockProjectList: ProjectResponse[] = [
+  {
+    projectId: 1,
+    name: 'Toaster Booth',
+    role: '프론트엔드 개발',
+    description:
+      '웹캠을 활용한 네컷 사진 촬영 웹 서비스입니다. 다양한 프레임, 텍스트 스티커 기능을 제공하며, 이미지 저장 시 Safari 대응을 위해 재시도 로직을 구현했습니다.',
+    shortDescription: '웹캠 네컷 사진 촬영 서비스',
+    achievement:
+      '런칭 후 2주 만에 2천 건 이상 사용, iOS Safari 이미지 저장 버그 해결 및 GitHub 이슈 공유',
+    github_link: 'https://github.com/yourname/toaster-booth',
+    blog_link: 'https://velog.io/@yourname/toaster-booth-retrospective',
+    deployed_link: 'https://toaster-booth.vercel.app/',
+    start_date: '2024-02-01',
+    end_date: '2024-02-20',
+    projectImageName: 'web_site_7.jpg',
+    mainImageName: 'web_site_7.jpg',
+    techStack: {
+      techStack: ['React', 'TypeScript', 'Vite', 'TailwindCSS', 'Supabase'],
+    },
+  },
+  {
+    projectId: 2,
+    name: '마일스톤 시스템',
+    role: '단독 개발 (프론트)',
+    description:
+      '소프트웨어 전공생들의 활동 기반 역량을 시각화하는 시스템입니다. 마일리지 등록, 검수, 누적 그래프 및 비교 분석 기능을 제공합니다.',
+    shortDescription: '전공 역량 분석 시스템',
+    achievement:
+      '교내 시범 운영, 사용자 만족도 설문 평균 4.8점, Safari 이미지 다운로드 이슈 대응 경험',
+    github_link: 'https://github.com/yourname/milestone-system',
+    blog_link: 'https://velog.io/@yourname/milestone-dev-story',
+    deployed_link: 'https://milestone.handong.edu/',
+    start_date: '2024-11-01',
+    end_date: '2024-12-31',
+    projectImageName: 'image033.png',
+    mainImageName: 'image033.png',
+    techStack: {
+      techStack: ['React', 'Zustand', 'TanStack Query', 'Emotion', 'MSW'],
+    },
+  },
+  {
+    projectId: 3,
+    name: 'Curio Quest',
+    role: '프론트엔드',
+    description:
+      '질문을 통해 진로를 탐색할 수 있는 진로 설계 서비스입니다. 퀴즈 기반 UX와 결과 분석 화면을 구현했습니다.',
+    shortDescription: '진로 탐색 퀴즈 서비스',
+    achievement: '교내 경진대회 최우수상 수상, 사용자 평균 참여율 87%',
+    github_link: 'https://github.com/yourname/curio-quest',
+    blog_link: 'https://velog.io/@yourname/curio-quest-review',
+    deployed_link: 'https://curio.quest.app/',
+    start_date: '2023-07-31',
+    end_date: '2023-08-18',
+    projectImageName: 'fm=pjpg',
+    mainImageName: 'fm=pjpg',
+    techStack: {
+      techStack: ['React', 'TypeScript', 'React Router', 'Firebase'],
+    },
+  },
+  {
+    projectId: 4,
+    name: 'Hanspace',
+    role: '프론트엔드',
+    description:
+      '학교 공간 예약 시스템입니다. 카카오 로그인, 공간 필터링, 예약 내역 확인 등의 기능을 제공합니다.',
+    shortDescription: '학교 공간 예약 시스템',
+    achievement:
+      '2023 한동대학교 교내 공모전 최우수상 수상, 4개 부서 실사용 도입',
+    github_link: 'https://github.com/yourname/hanspace',
+    blog_link: 'https://velog.io/@yourname/hanspace-log',
+    deployed_link: 'https://hanspace.handong.edu/',
+    start_date: '2023-09-01',
+    end_date: '',
+    projectImageName: 'img1.jpg',
+    mainImageName: 'img1.jpg',
+    techStack: {
+      techStack: [
+        'React',
+        'TypeScript',
+        'Recoil',
+        'Styled-Components',
+        'Kakao Auth',
+      ],
+    },
+  },
+  {
+    projectId: 5,
+    name: 'RentCheck 방끗',
+    role: 'UX 설계 및 프론트엔드',
+    description:
+      '처음 자취하는 사람들을 위한 체크리스트 기반 방 점검 서비스입니다. 사용자가 직접 문항을 선택하고, 점검을 하며 방 상태를 기록할 수 있습니다.',
+    shortDescription: '자취방 체크리스트 서비스',
+    achievement:
+      '교내 창업 아이디어 공모전 수상, 실제 자취생 대상 UX 테스트 진행',
+    github_link: 'https://github.com/yourname/bangkkeut',
+    blog_link: 'https://velog.io/@yourname/rentcheck-retro',
+    deployed_link: 'https://bangkkeut.vercel.app/',
+    start_date: '2024-08-01',
+    end_date: '2024-08-31',
+    projectImageName: '8e2d9579.png',
+    mainImageName: '8e2d9579.png',
+    techStack: {
+      techStack: ['Next.js', 'TypeScript', 'Zustand', 'Emotion', 'MSW'],
+    },
+  },
+  {
+    projectId: 6,
+    name: 'DevLog.me',
+    role: '프론트엔드 단독 개발',
+    description:
+      '개발자의 커리어와 프로젝트를 소개할 수 있는 미니 포트폴리오 사이트 빌더입니다. Markdown 기반 글쓰기와 다크모드 테마 전환 기능을 제공합니다.',
+    shortDescription: '개발자 포트폴리오 생성기',
+    achievement:
+      'GitHub Trending 진입, 개발자 커뮤니티에서 약 2,000회 이상 사용됨',
+    github_link: 'https://github.com/yourname/devlogme',
+    blog_link: 'https://velog.io/@yourname/devlog-maker-story',
+    deployed_link: 'https://devlog.me/',
+    start_date: '2024-05-15',
+    end_date: '2024-06-10',
+    projectImageName: '9C%EC%8B%9C.jpg',
+    mainImageName: '9C%EC%8B%9C.jpg',
+    techStack: {
+      techStack: ['React', 'Next.js', 'TailwindCSS', 'Gray-Matter', 'Vercel'],
+    },
+  },
+  {
+    projectId: 7,
+    name: '오늘뭐먹지?',
+    role: '프론트엔드 / 퍼블리싱',
+    description:
+      '메뉴 선택을 도와주는 가벼운 추천 서비스입니다. 유저가 선호도나 카테고리를 선택하면 오늘의 추천 메뉴를 카드 형태로 제공합니다.',
+    shortDescription: '메뉴 추천 웹앱',
+    achievement: '누적 방문자 1만명, UX 테스트를 통한 클릭률 20% 증가',
+    github_link: 'https://github.com/yourname/todayeat',
+    blog_link: '',
+    deployed_link: 'https://todayeat.app/',
+    start_date: '2023-06-01',
+    end_date: '2023-06-10',
+    projectImageName:
+      'https://qshop.ai/blog/wp-content/uploads/2024/05/%EC%9B%B9%EC%82%AC%EC%9D%B4%ED%8A%B8-%EC%A2%85%EB%A5%98-5%EA%B0%80%EC%A7%80%EC%99%80-%EB%AC%B4%EB%A3%8C-%EC%9B%B9%EC%82%AC%EC%9D%B4%ED%8A%B8-%EB%A7%8C%EB%93%A4%EA%B8%B0-4-1024x683.jpg',
+    mainImageName:
+      'https://qshop.ai/blog/wp-content/uploads/2024/05/%EC%9B%B9%EC%82%AC%EC%9D%B4%ED%8A%B8-%EC%A2%85%EB%A5%98-5%EA%B0%80%EC%A7%80%EC%99%80-%EB%AC%B4%EB%A3%8C-%EC%9B%B9%EC%82%AC%EC%9D%B4%ED%8A%B8-%EB%A7%8C%EB%93%A4%EA%B8%B0-4-1024x683.jpg',
+    techStack: {
+      techStack: ['Vue.js', 'TypeScript', 'SCSS'],
+    },
+  },
+  {
+    projectId: 8,
+    name: 'Todolist Pro',
+    role: '프론트엔드',
+    description:
+      '태그, 필터, 마감일 기반으로 할 일을 정리할 수 있는 To-do 앱입니다. 로컬스토리지와 IndexedDB를 활용해 오프라인 저장도 지원합니다.',
+    shortDescription: '강력한 할 일 관리 앱',
+    achievement: '피드백 기반 3차 리팩토링 진행, 모바일 사용자 만족도 92%',
+    github_link: 'https://github.com/yourname/todolist-pro',
+    blog_link: '',
+    deployed_link: 'https://todolist-pro.app/',
+    start_date: '2023-10-01',
+    end_date: '2023-10-20',
+    projectImageName: 'https://www.inodea.com/ino_rp/main/img/main_rpn02.jpg',
+    mainImageName: 'https://www.inodea.com/ino_rp/main/img/main_rpn02.jpg',
+    techStack: {
+      techStack: ['React', 'TypeScript', 'IndexedDB', 'Styled-Components'],
+    },
+  },
+];

--- a/src/mocks/handlers/auth.ts
+++ b/src/mocks/handlers/auth.ts
@@ -1,9 +1,8 @@
-import { http, HttpResponse } from 'msw';
-
 import { BASE_URL } from '@/apis/config';
 import { ENDPOINT } from '@/apis/endPoint';
 import { mockUserData } from '@/mocks/fixtures/auth';
 import { Error401, Error500, randomMswError } from '@/utils/mswError';
+import { http, HttpResponse } from 'msw';
 
 export const AuthHandlers = [
   http.post(BASE_URL + `${ENDPOINT.AUTH}/login`, () => {

--- a/src/mocks/handlers/award.ts
+++ b/src/mocks/handlers/award.ts
@@ -1,10 +1,8 @@
-import { http, HttpResponse } from 'msw';
-
 import { BASE_URL } from '@/apis/config';
 import { ENDPOINT } from '@/apis/endPoint';
-
 import { mockAwardList } from '@/mocks/fixtures/award';
 import { Error500, randomMswError } from '@/utils/mswError';
+import { http, HttpResponse } from 'msw';
 
 export const AwardHandlers = [
   http.get(BASE_URL + `${ENDPOINT.AWARD}`, () => {

--- a/src/mocks/handlers/capability.ts
+++ b/src/mocks/handlers/capability.ts
@@ -1,5 +1,3 @@
-import { http, HttpResponse } from 'msw';
-
 import { BASE_URL } from '@/apis/config';
 import { ENDPOINT } from '@/apis/endPoint';
 import { mockCapability } from '@/mocks/fixtures/capability';
@@ -9,6 +7,7 @@ import {
 } from '@/mocks/fixtures/compareCapability';
 import { mockSemesterCapability } from '@/mocks/fixtures/semesterCapability';
 import { Error401, Error500, randomMswError } from '@/utils/mswError';
+import { http, HttpResponse } from 'msw';
 
 export const CapabilityHandlers = [
   http.get(BASE_URL + `${ENDPOINT.CAPABILITY}/milestone`, () => {

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -3,6 +3,7 @@ import { AwardHandlers } from '@/mocks/handlers/award';
 import { CapabilityHandlers } from '@/mocks/handlers/capability';
 import { CommonHandlers } from '@/mocks/handlers/common';
 import { MileageHandlers } from '@/mocks/handlers/mileage';
+import { ProjectHandlers } from '@/mocks/handlers/project';
 import { ScholarshipHandlers } from '@/mocks/handlers/scholarship';
 
 export const handlers = [
@@ -11,5 +12,6 @@ export const handlers = [
   ...AuthHandlers,
   ...CapabilityHandlers,
   ...AwardHandlers,
+  ...ProjectHandlers,
   ...CommonHandlers,
 ];

--- a/src/mocks/handlers/project.ts
+++ b/src/mocks/handlers/project.ts
@@ -1,0 +1,15 @@
+import { BASE_URL } from '@/apis/config';
+import { ENDPOINT } from '@/apis/endPoint';
+import { http, HttpResponse } from 'msw';
+
+import { mockProjectList } from '@/mocks/fixtures/projectList';
+import { Error500, randomMswError } from '@/utils/mswError';
+
+export const ProjectHandlers = [
+  http.get(BASE_URL + `${ENDPOINT.PROJECT}`, () => {
+    const { is500Error } = randomMswError();
+    if (is500Error) return Error500();
+
+    return HttpResponse.json(mockProjectList, { status: 200 });
+  }),
+];

--- a/src/mocks/handlers/scholarship.ts
+++ b/src/mocks/handlers/scholarship.ts
@@ -1,9 +1,8 @@
-import { http, HttpResponse } from 'msw';
-
 import { BASE_URL } from '@/apis/config';
 import { ENDPOINT } from '@/apis/endPoint';
 import { mockScholarshipDuration } from '@/mocks/fixtures/scholarshipDuration';
 import { Error400, Error401, Error500, randomMswError } from '@/utils/mswError';
+import { http, HttpResponse } from 'msw';
 
 export const ScholarshipHandlers = [
   http.post(BASE_URL + `${ENDPOINT.SCHOLARSHIP_APPLY}/:studentId`, () => {

--- a/src/pages/DashboardPage/components/ProcessSection.tsx
+++ b/src/pages/DashboardPage/components/ProcessSection.tsx
@@ -23,10 +23,10 @@ export const ProcessSection = () => {
         <Heading as="h2" margin="0 0 .5rem" color={theme.palette.primary.main}>
           마일리지 장학금 신청 절차
         </Heading>
-        <Text style={{ fontSize: '12px' }}>
+        <Text style={{ fontSize: '.75rem' }}>
           반드시 마일리지 장학금 공지사항을 정독 후 신청하세요.
         </Text>
-        <Text style={{ fontSize: '12px' }}>
+        <Text style={{ fontSize: '.75rem' }}>
           아래 절차를 모두 완료해야 신청이 완료됩니다.
         </Text>
       </Flex.Column>

--- a/src/pages/ProjectArchivePage/apis/project.ts
+++ b/src/pages/ProjectArchivePage/apis/project.ts
@@ -1,0 +1,9 @@
+import { ENDPOINT } from '@/apis/endPoint';
+import { http } from '@/apis/http';
+
+import { ProjectResponse } from '../types/project';
+
+export const getProjectList = async () => {
+  const response = await http.get<ProjectResponse[]>(`${ENDPOINT.PROJECT}`);
+  return response;
+};

--- a/src/pages/ProjectArchivePage/components/AddProjectButton.tsx
+++ b/src/pages/ProjectArchivePage/components/AddProjectButton.tsx
@@ -1,0 +1,21 @@
+import { PlusIcon } from '@/assets';
+import { Button } from '@/components';
+import { ROUTE_PATH } from '@/constants/routePath';
+import { useNavigate } from 'react-router-dom';
+
+export const AddProjectButton = () => {
+  const navigate = useNavigate();
+
+  const handleMoveAddProject = () => {
+    navigate(ROUTE_PATH.newProject);
+  };
+
+  return (
+    <Button
+      label="새 프로젝트 추가하기"
+      size="medium"
+      icon={PlusIcon}
+      onClick={handleMoveAddProject}
+    />
+  );
+};

--- a/src/pages/ProjectArchivePage/components/EmptyProjectSection.tsx
+++ b/src/pages/ProjectArchivePage/components/EmptyProjectSection.tsx
@@ -1,0 +1,22 @@
+import { Flex, Heading, Text } from '@/components';
+
+export const EmptyProjectSection = () => {
+  return (
+    <Flex.Column
+      width="100%"
+      align="center"
+      justify="center"
+      padding="4rem 1rem"
+    >
+      <Flex.Row margin="1rem" style={{ fontSize: '3rem' }}>
+        📭
+      </Flex.Row>
+      <Heading as={'h2'} color="grey">
+        아직 등록된 프로젝트가 없어요
+      </Heading>
+      <Text as="p" color="grey">
+        첫 번째 프로젝트를 추가해보세요!
+      </Text>
+    </Flex.Column>
+  );
+};

--- a/src/pages/ProjectArchivePage/components/ProjectCard.tsx
+++ b/src/pages/ProjectArchivePage/components/ProjectCard.tsx
@@ -1,0 +1,79 @@
+import { Flex, Heading, Text } from '@/components';
+import { getFormattedDateFullYear } from '@/utils/getDate';
+import { styled } from '@mui/material';
+
+import { ProjectResponse } from '../types/project';
+
+export const ProjectCard = ({
+  project,
+  onClick,
+}: {
+  project: ProjectResponse;
+  onClick: () => void;
+}) => {
+  return (
+    <S.Card width="100%" height="320px" onClick={onClick}>
+      <S.Thumbnail
+        src={`/images/${project.mainImageName}`}
+        alt="프로젝트 대표 이미지"
+      />
+      <Flex.Column gap=".5rem" padding="1rem">
+        <Flex.Row>
+          <Heading as={'h3'}>{project.name}</Heading>
+        </Flex.Row>
+
+        <Text style={{ fontSize: '.875rem' }}>
+          {getFormattedDateFullYear(project.start_date)}{' '}
+          {project.end_date
+            ? `→ ${getFormattedDateFullYear(project.end_date)}`
+            : '→ ing'}
+        </Text>
+
+        <Flex.Row
+          wrap="wrap"
+          gap=".5rem"
+          style={{ maxHeight: '50px', overflow: 'hidden' }}
+        >
+          {project.techStack.techStack.map((tech, index) => (
+            <S.TechBadge as="span" key={index}>
+              {tech}
+            </S.TechBadge>
+          ))}
+        </Flex.Row>
+      </Flex.Column>
+    </S.Card>
+  );
+};
+
+const S = {
+  Card: styled(Flex.Column)`
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+    cursor: pointer;
+    max-width: 360px;
+    overflow: hidden;
+    transition: box-shadow 0.2s ease;
+
+    &:hover,
+    &:active {
+      box-shadow: 0 4px 12px rgb(0 0 0 / 20%);
+    }
+  `,
+  Thumbnail: styled('img')`
+    background-color: ${({ theme }) => theme.palette.primary.light};
+    height: 180px;
+    object-fit: cover;
+    width: 100%;
+  `,
+  DateText: styled(Text)`
+    background-color: ${({ theme }) => theme.palette.grey100};
+    padding: 0.125rem 0.5rem;
+  `,
+  TechBadge: styled(Text)`
+    background-color: ${({ theme }) => theme.palette.primary.light};
+    border-radius: 24px;
+    color: ${({ theme }) => theme.palette.primary.main};
+    font-size: 0.75rem;
+    padding: 0.125rem 0.5rem;
+  `,
+};

--- a/src/pages/ProjectArchivePage/components/ProjectCardSkeleton.tsx
+++ b/src/pages/ProjectArchivePage/components/ProjectCardSkeleton.tsx
@@ -1,0 +1,36 @@
+import { Flex } from '@/components';
+import { Skeleton, styled } from '@mui/material';
+
+export const ProjectCardSkeleton = () => {
+  return (
+    <S.Card width="100%" height="320px">
+      <Skeleton variant="rectangular" height={180} width="100%" />
+
+      <Flex.Column gap=".5rem" padding="1rem">
+        <Skeleton variant="text" width="60%" height={24} />
+        <Skeleton variant="text" width="40%" height={18} />
+
+        <Flex.Row wrap="wrap" gap=".5rem">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton
+              key={i}
+              variant="rounded"
+              width={60}
+              height={24}
+              style={{ borderRadius: '24px' }}
+            />
+          ))}
+        </Flex.Row>
+      </Flex.Column>
+    </S.Card>
+  );
+};
+
+const S = {
+  Card: styled(Flex.Column)`
+    border-radius: 12px;
+    box-shadow: 0 4px 12px rgb(0 0 0 / 10%);
+    max-width: 360px;
+    overflow: hidden;
+  `,
+};

--- a/src/pages/ProjectArchivePage/components/ProjectGridSection.tsx
+++ b/src/pages/ProjectArchivePage/components/ProjectGridSection.tsx
@@ -1,0 +1,40 @@
+import { MAX_RESPONSIVE_WIDTH } from '@/constants/system';
+import { styled, useMediaQuery } from '@mui/material';
+
+import { ROUTE_PATH } from '@/constants/routePath';
+import { EmptyProjectSection } from '@/pages/ProjectArchivePage/components/EmptyProjectSection';
+import { useNavigate } from 'react-router-dom';
+import { useGetProjectsQuery } from '../hooks/useGetProjectsQuery';
+import { ProjectCard } from './ProjectCard';
+
+export const ProjectGridSection = () => {
+  const navigate = useNavigate();
+  const { projects } = useGetProjectsQuery();
+  const isMobile = useMediaQuery(MAX_RESPONSIVE_WIDTH);
+
+  if (!projects.length) return <EmptyProjectSection />;
+  return (
+    <S.Grid isMobile={isMobile}>
+      {projects.map(project => (
+        <ProjectCard
+          key={project.projectId}
+          project={project}
+          onClick={() => navigate(ROUTE_PATH.projectDetail(project.projectId))}
+        />
+      ))}
+    </S.Grid>
+  );
+};
+
+const S = {
+  Grid: styled('div')<{ isMobile: boolean }>`
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: ${({ isMobile }) =>
+      isMobile ? 'repeat(1, 1fr)' : 'repeat(4, 1fr)'};
+    height: fit-content;
+    justify-items: center;
+    overflow-y: scroll;
+    padding: 1rem 0;
+  `,
+};

--- a/src/pages/ProjectArchivePage/components/ProjectGridSection.tsx
+++ b/src/pages/ProjectArchivePage/components/ProjectGridSection.tsx
@@ -1,10 +1,10 @@
+import { ROUTE_PATH } from '@/constants/routePath';
 import { MAX_RESPONSIVE_WIDTH } from '@/constants/system';
 import { styled, useMediaQuery } from '@mui/material';
-
-import { ROUTE_PATH } from '@/constants/routePath';
-import { EmptyProjectSection } from '@/pages/ProjectArchivePage/components/EmptyProjectSection';
 import { useNavigate } from 'react-router-dom';
+
 import { useGetProjectsQuery } from '../hooks/useGetProjectsQuery';
+import { EmptyProjectSection } from './EmptyProjectSection';
 import { ProjectCard } from './ProjectCard';
 
 export const ProjectGridSection = () => {

--- a/src/pages/ProjectArchivePage/components/ProjectGridSkeleton.tsx
+++ b/src/pages/ProjectArchivePage/components/ProjectGridSkeleton.tsx
@@ -1,0 +1,28 @@
+import { MAX_RESPONSIVE_WIDTH } from '@/constants/system';
+import { styled, useMediaQuery } from '@mui/material';
+
+import { ProjectCardSkeleton } from './ProjectCardSkeleton';
+
+export const ProjectGridSkeleton = () => {
+  const isMobile = useMediaQuery(MAX_RESPONSIVE_WIDTH);
+
+  return (
+    <S.Grid isMobile={isMobile}>
+      {Array.from({ length: 4 }).map((_, i) => (
+        <ProjectCardSkeleton key={i} />
+      ))}
+    </S.Grid>
+  );
+};
+
+const S = {
+  Grid: styled('div')<{ isMobile: boolean }>`
+    display: grid;
+    gap: 1rem;
+    grid-template-columns: ${({ isMobile }) =>
+      isMobile ? 'repeat(1, 1fr)' : 'repeat(4, 1fr)'};
+    height: fit-content;
+    justify-items: center;
+    padding: 1rem 0;
+  `,
+};

--- a/src/pages/ProjectArchivePage/hooks/useGetProjectsQuery.ts
+++ b/src/pages/ProjectArchivePage/hooks/useGetProjectsQuery.ts
@@ -1,0 +1,14 @@
+import { QUERY_KEYS } from '@/constants/queryKeys';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { getProjectList } from '../apis/project';
+import { ProjectResponse } from '../types/project';
+
+export const useGetProjectsQuery = () => {
+  const { data, ...rest } = useSuspenseQuery<ProjectResponse[]>({
+    queryKey: [QUERY_KEYS.award],
+    queryFn: getProjectList,
+  });
+
+  return { projects: data, ...rest };
+};

--- a/src/pages/ProjectArchivePage/index.tsx
+++ b/src/pages/ProjectArchivePage/index.tsx
@@ -1,0 +1,39 @@
+import { DeferredComponent, Flex, PageErrorFallback } from '@/components';
+import { useTrackPageView } from '@/service/amplitude/useTrackPageView';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+
+import { AddProjectButton } from './components/AddProjectButton';
+import { ProjectGridSection } from './components/ProjectGridSection';
+import { ProjectGridSkeleton } from './components/ProjectGridSkeleton';
+
+const ProjectArchivePage = () => {
+  useTrackPageView({ eventName: '[View] 프로젝트 조회 페이지' });
+
+  return (
+    <Flex.Column margin="1rem">
+      <Flex.Row justify="flex-end" align="center">
+        <AddProjectButton />
+      </Flex.Row>
+
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary FallbackComponent={PageErrorFallback} onReset={reset}>
+            <Suspense
+              fallback={
+                <DeferredComponent>
+                  <ProjectGridSkeleton />
+                </DeferredComponent>
+              }
+            >
+              <ProjectGridSection />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </Flex.Column>
+  );
+};
+
+export default ProjectArchivePage;

--- a/src/pages/ProjectArchivePage/types/project.ts
+++ b/src/pages/ProjectArchivePage/types/project.ts
@@ -1,0 +1,18 @@
+export interface ProjectResponse {
+  projectId: number; // 프로젝트 고유 ID (PK)
+  name: string; // 프로젝트 이름
+  role: string; // 프로젝트에서 맡은 역할
+  description: string; // 프로젝트 상세 설명 (긴 글)
+  shortDescription: string; // 한 줄 설명
+  achievement: string; // 성과 설명
+  github_link: string; // GitHub 링크
+  blog_link: string; // 블로그 링크
+  deployed_link: string; // 배포된 서비스 링크
+  start_date: string; // 프로젝트 시작일 (YYYY-MM-DD)
+  end_date: string; // 프로젝트 종료일 (YYYY-MM-DD)
+  projectImageName: string; // 대표 이미지 파일명 (로고 등)
+  mainImageName: string; // 대표 스크린샷 이미지 파일명
+  techStack: {
+    techStack: string[]; // 사용한 기술 스택 리스트
+  };
+}

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -7,6 +7,9 @@ const DashboardPage = React.lazy(() => import('@/pages/DashboardPage'));
 const MileageListPage = React.lazy(() => import('@/pages/MileageListPage'));
 const AddMileagePage = React.lazy(() => import('@/pages/AddMileagePage'));
 const AwardArchivePage = React.lazy(() => import('@/pages/AwardArchivePage'));
+const ProjectArchivePage = React.lazy(
+  () => import('@/pages/ProjectArchivePage'),
+);
 const ScholarshipApplyPage = React.lazy(
   () => import('@/pages/ScholarshipApplyPage'),
 );
@@ -40,6 +43,10 @@ const router = createBrowserRouter(
         {
           path: ROUTE_PATH.award,
           element: <AwardArchivePage />,
+        },
+        {
+          path: ROUTE_PATH.project,
+          element: <ProjectArchivePage />,
         },
         {
           path: ROUTE_PATH.scholarship,

--- a/src/utils/getDate.ts
+++ b/src/utils/getDate.ts
@@ -16,3 +16,13 @@ export const getFormattedDate = (stringDate: string) => {
 
   return `${month}월 ${day}일`;
 };
+
+export const getFormattedDateFullYear = (stringDate: string) => {
+  const date = new Date(stringDate);
+
+  const year = ('0' + date.getFullYear()).slice(-4);
+  const month = ('0' + (date.getMonth() + 1)).slice(-2);
+  const day = ('0' + date.getDate()).slice(-2);
+
+  return `${year}년 ${month}월 ${day}일`;
+};


### PR DESCRIPTION
## 💵 관련 이슈

- #101 

## ✨ 구현한 기능

> 구현 기능에 대해 작성해주세요.

<img width="1440" alt="스크린샷 2025-05-11 오전 2 38 18" src="https://github.com/user-attachments/assets/3221a44a-1422-4358-a3b1-6a13fea9c334" />

### 프로젝트 목록 페이지의 전체 뷰 및 관련 API 연동, 라우팅 설정, 빈 상태 처리 등을 구현했습니다.

- 라우팅 설정
   - /project → 프로젝트 목록 페이지
   - /project/:id → 프로젝트 상세 페이지 (라우팅만 세팅됨)
- API 연동
   - GET /projects API 연동 완료
   - useGetProjectsQuery 커스텀 훅 구현
- 컴포넌트 구현
   - ProjectCard: 프로젝트 카드 UI 컴포넌트
   - ProjectGridSection: 그리드 레이아웃 구성 및 반응형 처리
   - EmptyProjectSection: 프로젝트가 없을 경우 사용자에게 안내
   - ProjectCardSkeleton: 로딩 상태에서 보여질 스켈레톤 UI
   - 새로운 프로젝트 생성 버튼 추가


## 📢 논의하고 싶은 내용

> 고려해야 하는 내용을 작성해 주세요.

## 🍗 PR 첫 리뷰 마감 기한

00/00 00:00
